### PR TITLE
Update Examples, MD, CS

### DIFF
--- a/CapabilityStatement/BARS-CapabilityStatement-example.xml
+++ b/CapabilityStatement/BARS-CapabilityStatement-example.xml
@@ -4,7 +4,7 @@
 	<name value="BaRS FHIR Server CapabilityStatement"/>
 	<status value="active"/>
 	<!-- This is the version of BaRS Core -->
-	<version value="1.2.2"/>
+	<version value="1.1.0"/>
 	<experimental value="false"/>
 	<date value="2024-01-09"/>
 	<publisher value="NHS England"/>

--- a/Examples/REFREQ01 - Referral Service Request New Full - 111 to ED.xml
+++ b/Examples/REFREQ01 - Referral Service Request New Full - 111 to ED.xml
@@ -1,7 +1,7 @@
 <Bundle xmlns="http://hl7.org/fhir">
   <id value="79120f41-a431-4f08-bcc5-1e67006fcae0" />
   <meta>
-    <versionId value="1.1.0" />
+    <versionId value="1.0.0" />
     <lastUpdated value="2021-10-11T15:23:30.8185338+00:00" />
     <profile value="https://fhir.nhs.uk/StructureDefinition/BARSBundleMessage" />
   </meta>
@@ -188,6 +188,11 @@
             <!--    Important for driving workflow, determining the type of referral being requested    -->
             <display value="Transfer of Care" />
           </coding>
+					<coding><!--       Use case category      -->
+						<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars" />
+						<code value="a1t1" />
+						<display value="111 - ED" />
+					</coding>
         </category>
         <subject>
           <reference value="urn:uuid:9589fb37-87a2-48d8-968f-b371429208a8" />

--- a/Examples/REFREQ02 - Referral Service Request New Full - 999 to CAS.xml
+++ b/Examples/REFREQ02 - Referral Service Request New Full - 999 to CAS.xml
@@ -1,7 +1,7 @@
 <Bundle xmlns="http://hl7.org/fhir">
   <id value="79120f41-a431-4f08-bcc5-1e67006fcae0" />
   <meta>
-    <versionId value="1.1.0" />
+    <versionId value="1.0.0" />
     <lastUpdated value="2021-11-26T15:00:00.8185338+00:00" />
     <profile value="https://fhir.nhs.uk/StructureDefinition/BARSBundleMessage" />
   </meta>
@@ -88,6 +88,11 @@
             <!--   Important for driving workflow, determining the type of referral being requested   -->
             <display value="Transfer of Care" />
           </coding>
+					<coding><!--       Use case category      -->
+						<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars" />
+						<code value="a3t1" />
+						<display value="999-CAS Referral" />
+					</coding>
         </category>
         <subject>
           <reference value="urn:uuid:9589fb37-87a2-48d8-968f-b371429208a8" />

--- a/Examples/REFREQ04 - Referral Service Request - CAD Out of Area.xml
+++ b/Examples/REFREQ04 - Referral Service Request - CAD Out of Area.xml
@@ -1,7 +1,7 @@
 <Bundle xmlns="http://hl7.org/fhir">
     <id value="86e3371d-1c15-4862-9552-d9560f8292ba" />
     <meta>
-        <versionId value="1.1.0" />
+        <versionId value="1.0.0-beta" />
         <lastUpdated value="2023-12-26T15:00:00.8185338+00:00" />
         <profile value="https://fhir.nhs.uk/StructureDefinition/BARSBundleMessage" />
     </meta>

--- a/Examples/REFREQ05 - Referral Service Request - CAD Mutal Aid Request.xml
+++ b/Examples/REFREQ05 - Referral Service Request - CAD Mutal Aid Request.xml
@@ -1,7 +1,7 @@
 <Bundle xmlns="http://hl7.org/fhir">
     <id value="c4b190d6-9623-4235-859d-e3d4c09d5658" />
     <meta>
-        <versionId value="1.1.0" />
+        <versionId value="1.0.0-beta" />
         <lastUpdated value="2023-12-26T15:00:00.8185338+00:00" />
         <profile value="https://fhir.nhs.uk/StructureDefinition/BARSBundleMessage" />
     </meta>

--- a/Examples/REFRESP01 - Referral Service Request Response New Full - ED to 111 Safeguarding DNA Feedback.xml
+++ b/Examples/REFRESP01 - Referral Service Request Response New Full - ED to 111 Safeguarding DNA Feedback.xml
@@ -1,7 +1,7 @@
 <Bundle xmlns="http://hl7.org/fhir">
   <id value="bc040878-cf51-4acf-9ede-7448fbb5be7c" />
   <meta>
-    <versionId value="1.1.0" />
+    <versionId value="1.0.0" />
     <lastUpdated value="2021-10-11T15:23:30.8185338+00:00" />
     <profile value="https://fhir.nhs.uk/StructureDefinition/BARSBundleMessage" />
   </meta>
@@ -85,6 +85,11 @@
             <!--   Important for driving workflow, determining the type of referral being requested   -->
             <display value="Transfer of Care" />
           </coding>
+					<coding><!--       Use case category      -->
+						<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars" />
+						<code value="a1t1" />
+						<display value="111 - ED" />
+					</coding>
         </category>
         <subject>
           <reference value="urn:uuid:9589fb37-87a2-48d8-968f-b371429208a8" />

--- a/Examples/REFRESP02- Referral Service Request Reponse Short - CAD Mutual Aid Rejection.xml
+++ b/Examples/REFRESP02- Referral Service Request Reponse Short - CAD Mutual Aid Rejection.xml
@@ -1,7 +1,7 @@
 <Bundle xmlns="http://hl7.org/fhir">
     <id value="ca337cfa-f564-4948-97bf-4134968caba6" />
     <meta>
-        <versionId value="1.0.0" />
+        <versionId value="1.0.0-beta" />
         <lastUpdated value="2023-12-26T15:30:00.8185338+00:00" />
         <profile value="https://fhir.nhs.uk/StructureDefinition/BARSBundleMessage" />
     </meta>
@@ -91,7 +91,7 @@
 					<coding><!--       Use case category      -->
 						<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars" />
 						<code value="a6t3" />
-						<display value="999-999 Mutual Aid Request" />
+						<display value="CAD to CAD Mutual Aid Request" />
 					</coding>
 					<text value="Please can you spare a Paramedic closer than 20 mins?" />
                 </category>

--- a/Examples/REFRESP03 - Referral Service Request Response - CAD Out of Area Response.xml
+++ b/Examples/REFRESP03 - Referral Service Request Response - CAD Out of Area Response.xml
@@ -1,7 +1,7 @@
 <Bundle xmlns="http://hl7.org/fhir">
     <id value="dcd2aaa9-efe2-4df2-bb34-ad4ee9a41f28" />
     <meta>
-        <versionId value="1.0.0" />
+        <versionId value="1.0.0-beta" />
         <lastUpdated value="2023-12-26T15:30:00.8185338+00:00" />
         <profile value="https://fhir.nhs.uk/StructureDefinition/BARSBundleMessage" />
     </meta>

--- a/Examples/SERVREQ01 - Service Request Update - Revoked.xml
+++ b/Examples/SERVREQ01 - Service Request Update - Revoked.xml
@@ -83,6 +83,11 @@
             <!--   Important for driving workflow, determining the type of referral being requested   -->
             <display value="For Validation" />
           </coding>
+					<coding><!--       Use case category      -->
+						<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars" />
+						<code value="a4t1" />
+						<display value="999 - CAS Validation" />
+					</coding>
         </category>
         <subject>
           <reference value="urn:uuid:9589fb37-87a2-48d8-968f-b371429208a8" />

--- a/Examples/SERVREQ02 - Service Request Delete - Entered in error.xml
+++ b/Examples/SERVREQ02 - Service Request Delete - Entered in error.xml
@@ -82,6 +82,11 @@
             <!--   Important for driving workflow, determining the type of referral being requested   -->
             <display value="For Validation" />
           </coding>
+					<coding><!--       Use case category      -->
+						<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars" />
+						<code value="a4t1" />
+						<display value="999 - CAS Validation" />
+					</coding>
         </category>
         <subject>
           <reference value="urn:uuid:9589fb37-87a2-48d8-968f-b371429208a8" />

--- a/MessageDefinition/BARS-MessageDefinition-Booking-Request.xml
+++ b/MessageDefinition/BARS-MessageDefinition-Booking-Request.xml
@@ -6,7 +6,7 @@
 	<status value="active"/>
 	<date value="2023-10-16"/>
 	<!-- This is the version number of Application 1 -->
-	<version value="1.0.3"/>
+	<version value="1.0.0"/>
 	<eventCoding>
 		<system value="https://fhir.nhs.uk/CodeSystem/message-events-bars"/>
 		<code value="booking-request"/>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Request-Referral.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Request-Referral.xml
@@ -30,6 +30,7 @@
 			<!--  Use cases supported by this MessageDefinition for Application 6  -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a6t3"/>
+			<display value="CAD to CAD Mutual Aid Request" />
 		</code>
 		<valueCodeableConcept>
 			<coding>
@@ -42,6 +43,7 @@
 		<code>
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a6t2"/>
+			<display value="CAD to CAD Call Assist Request" />
 		</code>
 		<valueCodeableConcept>
 			<coding>
@@ -54,6 +56,7 @@
 		<code>
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a6t1"/>
+			<display value="CAD to CAD Out of Area Request" />
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Request-Validation.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Request-Validation.xml
@@ -29,7 +29,7 @@
 		<code>
 			<!--  Use cases supported by this MessageDefinition for Application 4  -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
-			<code value="999casvalidation"/>
+			<code value="a4t1"/>
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Request-Validation.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Request-Validation.xml
@@ -30,6 +30,7 @@
 			<!--  Use cases supported by this MessageDefinition for Application 4  -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a4t1"/>
+			<display value="999-CAS Validation" />
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Referral-Short.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Referral-Short.xml
@@ -28,7 +28,7 @@
 		<code>
 			<!--  Use cases supported by this MessageDefinition Application 6-->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
-			<code value="999to999mutualaidrequest"/>
+			<code value="a6t3"/>
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Referral-Short.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Referral-Short.xml
@@ -5,7 +5,7 @@
 	<title value="BARS Message Definition ServiceRequest - Response Referral Short"/>
 	<status value="active"/>
 	<date value="2023-12-28"/>
-	<!-- This is the version number of Application 6 (currently in development on Simplifier) -->
+	<!-- This is the version number of Application (currently in development on Simplifier) -->
 	<version value="1.0.0-beta"/>
 	<eventCoding>
 		<system value="https://fhir.nhs.uk/CodeSystem/message-events-bars"/>
@@ -26,9 +26,10 @@
 	</useContext>
 	<useContext>
 		<code>
-			<!--  Use cases supported by this MessageDefinition Application 6-->
+			<!--  Use cases supported by this MessageDefinition Application -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a6t3"/>
+			<display value="CAD to CAD Mutual Aid Request" />
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Referral.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Referral.xml
@@ -29,6 +29,7 @@
 			<!--  Use cases supported by this MessageDefinition for Application 6  -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a6t3"/>
+			<display value="CAD to CAD Mutual Aid Request" />
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Referral.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Referral.xml
@@ -28,7 +28,7 @@
 		<code>
 			<!--  Use cases supported by this MessageDefinition for Application 6  -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
-			<code value="999to999mutualaidrequest"/>
+			<code value="a6t3"/>
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Validation-Full.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Validation-Full.xml
@@ -29,6 +29,7 @@
 			<!--  Use cases supported by this MessageDefinition for Application 6  -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a4t1"/>
+			<display value="999-CAS Validation" />
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Validation-Full.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Validation-Full.xml
@@ -24,6 +24,19 @@
 			</coding>
 		</valueCodeableConcept>
 	</useContext>
+	<useContext>
+		<code>
+			<!--  Use cases supported by this MessageDefinition for Application 6  -->
+			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
+			<code value="a4t1"/>
+		</code>
+		<valueCodeableConcept>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/variant-state"/>
+				<code value="positive"/>
+			</coding>
+		</valueCodeableConcept>
+	</useContext>
 	<focus>
 		<code value="Bundle"/>
 		<profile value="https://fhir.nhs.uk/StructureDefinition/BARSBundleMessage"/>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Validation-Interim.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Validation-Interim.xml
@@ -25,6 +25,7 @@
 			<!--  Use cases supported by this MessageDefinition for Application 6  -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a4t1"/>
+			<display value="999-CAS Validation" />
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Validation-Interim.xml
+++ b/MessageDefinition/BARS-MessageDefinition-ServiceRequest-Response-Validation-Interim.xml
@@ -20,6 +20,19 @@
 			</coding>
 		</valueCodeableConcept>
 	</useContext>
+	<useContext>
+		<code>
+			<!--  Use cases supported by this MessageDefinition for Application 6  -->
+			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
+			<code value="a4t1"/>
+		</code>
+		<valueCodeableConcept>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/variant-state"/>
+				<code value="positive"/>
+			</coding>
+		</valueCodeableConcept>
+	</useContext>
 	<eventCoding>
 		<system value="https://fhir.nhs.uk/CodeSystem/message-events-bars"/>
 		<code value="servicerequest-response"/>

--- a/MessageDefinition/BARSMessageDefinitionBookingRequestCancelled.xml
+++ b/MessageDefinition/BARSMessageDefinitionBookingRequestCancelled.xml
@@ -6,7 +6,7 @@
 	<status value="active"/>
 	<date value="2023-10-16"/>
 	<!-- This is the version number of Application 1 -->
-	<version value="1.0.3"/>
+	<version value="1.0.0"/>
 	<eventCoding>
 		<system value="https://fhir.nhs.uk/CodeSystem/message-events-bars"/>
 		<code value="booking-request"/>

--- a/MessageDefinition/BARSMessageDefinitionServiceRequestRequestCancelled.xml
+++ b/MessageDefinition/BARSMessageDefinitionServiceRequestRequestCancelled.xml
@@ -5,7 +5,7 @@
 	<title value="BARS Message Definition ServiceRequest - Request - Cancelled"/>
 	<status value="active"/>
 	<date value="2023-10-16"/>
-	<!-- This is the version number of Application 6 (currently in development on Simplifier) -->
+	<!-- This is the version number of Application (currently in development on Simplifier) -->
 	<version value="1.0.0"/>
 	<eventCoding>
 		<system value="https://fhir.nhs.uk/CodeSystem/message-events-bars"/>
@@ -26,9 +26,10 @@
 	</useContext>
 	<useContext>
 		<code>
-			<!--  Use cases supported by this MessageDefinition for Application 6  -->
+			<!--  Use cases supported by this MessageDefinition for Application  -->
 			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
 			<code value="a1t1"/>
+			<display value="111 - ED" />
 		</code>
 		<valueCodeableConcept>
 			<coding>

--- a/MessageDefinition/BARSMessageDefinitionServiceRequestRequestCancelled.xml
+++ b/MessageDefinition/BARSMessageDefinitionServiceRequestRequestCancelled.xml
@@ -6,7 +6,7 @@
 	<status value="active"/>
 	<date value="2023-10-16"/>
 	<!-- This is the version number of Application 6 (currently in development on Simplifier) -->
-	<version value="1.0.0-beta"/>
+	<version value="1.0.0"/>
 	<eventCoding>
 		<system value="https://fhir.nhs.uk/CodeSystem/message-events-bars"/>
 		<code value="servicerequest-request"/>
@@ -16,6 +16,19 @@
 		<code>
 			<system value="https://fhir.nhs.uk/CodeSystem/dos-id"/>
 			<code value="dos-id"/>
+		</code>
+		<valueCodeableConcept>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/variant-state"/>
+				<code value="positive"/>
+			</coding>
+		</valueCodeableConcept>
+	</useContext>
+	<useContext>
+		<code>
+			<!--  Use cases supported by this MessageDefinition for Application 6  -->
+			<system value="https://fhir.nhs.uk/CodeSystem/usecases-categories-bars"/>
+			<code value="a1t1"/>
 		</code>
 		<valueCodeableConcept>
 			<coding>


### PR DESCRIPTION
Updated examples to include UseContext where it was missing. Also updated bundle version to match the Application version, updated MessageDef version to match application version dropping the patch, updated Capability Statement with Core Version.