### PR TITLE
Minor changes to Assure/Cancellation pages

### DIFF
--- a/guides/Live-ImplementationGuide-BaRS/Home/Assure/Assure/SCAL.page.md
+++ b/guides/Live-ImplementationGuide-BaRS/Home/Assure/Assure/SCAL.page.md
@@ -12,7 +12,7 @@ An **end-to-end real-time demonstration** of the solution will be required as pa
 
 The SCAL is completed [online](https://digital.nhs.uk/developer/guides-and-documentation/digital-onboarding). There is further guidance on how to complete the SCAL below. 
 
-Request for an **Account Manager** to be set up by sending an email to the BaRS Team <bookingandreferralstandard@nhs.net>, including details of your Organisation, Product and which {{pagelink:Applications, text:BaRS Application}} you are undertaking, and you will be prompted to create an account with [Digital Onboarding Services](https://onboarding.prod.api.platform.nhs.uk/) via a link. 
+When you are ready to start the assurance process, send an email to the BaRS Team <bookingandreferralstandard@nhs.net>, including details of your Organisation, Product and which {{pagelink:Applications, text:BaRS Application}} you are undertaking, and you will be prompted to create an account with [Digital Onboarding Services](https://onboarding.prod.api.platform.nhs.uk/) via a link. 
 
 ### Planning your assurance
 

--- a/guides/Live-ImplementationGuide-BaRS/Home/Core/1.0.4/Standard-Pattern-Composite-Messages/Cancellation.page.md
+++ b/guides/Live-ImplementationGuide-BaRS/Home/Core/1.0.4/Standard-Pattern-Composite-Messages/Cancellation.page.md
@@ -16,7 +16,7 @@ A prerequisite when performing a cancellation of any request is to perform a rea
 ### MessageHeader Resource
 {{pagelink:core-SPMessageHeader-1.0.4, text:Standard Patterns for BaRS Operations}} explains in detail how the **MessageHeader** resource **must** be used. 
 
-When cancelling a referral, in conjunction with the guidance provided under the Standard Patterns, the three important elements which drive workflow **must** be used as follows: 
+When cancelling a referral, in conjunction with the guidance provided under the Standard Patterns, the four important elements which drive workflow **must** be used as follows: 
 * **eventCoding** - this **must** be the same code as used in the request.
 * **reasonCode** - a cancellation follows an initial request, therefore, this **must** always be 'update' for cancellation.
 * **definition** - cancellation has a unique [MessageDefinition](https://simplifier.net/nhsbookingandreferrals/~resources?category=Example&exampletype=MessageDefinition&sortBy=DisplayName) the request **must** adhere to.


### PR DESCRIPTION
Removed reference to Account manager from Assurance/SCAL Changed number three to four in Cancellation page.