### PR TITLE
Release Note updates and backport

### DIFF
--- a/guides/Live-ImplementationGuide-BaRS/Home/About-BaRS/Releases/Technical-Release-Notes/BaRS-Core/1.3.0.page.md
+++ b/guides/Live-ImplementationGuide-BaRS/Home/About-BaRS/Releases/Technical-Release-Notes/BaRS-Core/1.3.0.page.md
@@ -9,6 +9,9 @@ topic: TRN-Core-1.3.0
 | Standard Pattern Composite Messages - Cancellation  | bundle.meta.versionID added to payload for consistency across BaRS documentation|    <mark style="background-color: Yellow">correction</mark>  | 
 | Failure Scenarios - GET /Slots | Link text <FHIR instant> update to <FHIR dateTime> for consistency|    <mark style="background-color: Yellow">correction</mark>  | 
 | Transactional Integrity | Post 409 Failure Scenario image updated to demonstrate 408 response |    <mark style="background-color: Yellow">correction</mark>  |
+| New Standard Pattern for Find Resources | New Standard Pattern highlighting the different ways to obtain (resource).Id values to perform updates, including the use of new API parameters which support patient demographics |    <mark style="background-color: Green">Non-breaking</mark>  |
+| Standard Pattern Cancellation updated | Standard Pattern Cancellation updated to reference the new Find Resource Standard Pattern |    <mark style="background-color: Green">Non-breaking</mark>  |
+| Appointment Foundation updated | Appointment Foundation updated to reference the new Find Resource Standard Pattern |    <mark style="background-color: Green">Non-breaking</mark>  |
 <br>
 <hr>
 

--- a/guides/Live-ImplementationGuide-BaRS/Home/About-BaRS/Releases/Technical-Release-Notes/TRN-APP5/1.0.0.page.md
+++ b/guides/Live-ImplementationGuide-BaRS/Home/About-BaRS/Releases/Technical-Release-Notes/TRN-APP5/1.0.0.page.md
@@ -31,6 +31,27 @@ This is the first stable release (v1.0.0) of Application 5 and reinstates key fu
 |------------------------------------------------------|----------|------------|---------|------------------|-------------------------------------------------------------------------------------------------|----------|
 | | || |                                ||
 
+### Backported Requirements
+
+### Application Change Log (Backported from 1.1.2)
+
+
+<br>
+
+
+| Change                                    | Description                                     | Impact                                                                  | 
+|-------------------------------------------|-------------------------------------------------|-------------------------------------------------------------------------|
+| SNOMED Code Updated  | The SNOMED Code used to define a minor illness referral has been updated from '1577041000000100-Community Pharmacist Consultation Service for minor illness (procedure)' to '2140231000000104-Referral to Community Pharmacy Pharmacy First Service (procedure)', as requested by Pharmacy First Programme Clinical Lead |  <mark style="background-color: Yellow">correction</mark>  |
+
+    
+### Payload Change Log (Backported from 1.1.2)
+
+| FHIR Element                                         | Previous | Current    | Other   | Referral/Booking | Rationale                                                                                       |  Impact  |
+|------------------------------------------------------|----------|------------|---------|------------------|-------------------------------------------------------------------------------------------------|----------|
+| Task.code.coding.code  | 1577041000000100          |  2140231000000104         | Update        | Referral Request         |SNOMED Code changed     |   <mark style="background-color: LightGreen">non-breaking</mark> |
+| Task.code.coding.display  | Community Pharmacist Consultation Service for minor illness (procedure)          | Referral to Community Pharmacy Pharmacy First Service (procedure)          | Update        | Referral Request         |SNOMED Code changed     |   <mark style="background-color: LightGreen">non-breaking</mark> |
+| encounter.class.display  |          |            | Update        | Referral Request         |encounter.class.display value corrected from "Emergency" to "emergency" in Implementation Guidance   |   <mark style="background-color: Yellow">correction</mark>  |
+
 </div>
 </div>
 

--- a/guides/Live-ImplementationGuide-BaRS/Home/About-BaRS/Releases/Technical-Release-Notes/TRN-APP5/1.1.3.page.md
+++ b/guides/Live-ImplementationGuide-BaRS/Home/About-BaRS/Releases/Technical-Release-Notes/TRN-APP5/1.1.3.page.md
@@ -15,7 +15,9 @@ This stable release (v1.1.3) of Application 5 sees minor corrections.
 |-------------------------------------------|-------------------------------------------------|-------------------------------------------------------------------------|
 | Simplified cancellation guidance   | Updated cancellation guidance, for referrals, under 'How does it work?', now pointing to Standard Patterns documentation. Reworded the description on use of Message Definitions when building a cancellation request. |   <mark style="background-color: LightGreen">non-breaking</mark>  |
 | MedicationStatement  |  Link path updated in Referral Request |    <mark style="background-color: Yellow">correction</mark>  |  
-| Referral Request  | bundle.meta.versionID added to payload for consistency across BaRS documentation|    <mark style="background-color: Yellow">correction</mark>  | 
+| Referral Request  | bundle.meta.versionID added to payload for consistency across BaRS documentation|    <mark style="background-color: Yellow">correction</mark>  |
+| (Backport) Updated SNOMED Task.code value to v1.0.0  | Added updated SNOMED code Task.Code from 1.1.2 to 1.0.0 to allow new code to be used with the need to implement new OC and BP use cases, at the request of Pharmacy First |    <mark style="background-color: LightGreen">non-breaking</mark> |
+ 
 
     
 ### Payload Change Log


### PR DESCRIPTION
1.3 Core RN
backported SNOMED Code update in Application 5 from 1.1.2 to 1.0.0, at the request of Pharmacy First programme.